### PR TITLE
small handlers refactoring

### DIFF
--- a/handlers/error.go
+++ b/handlers/error.go
@@ -1,0 +1,16 @@
+package handlers
+
+import "fmt"
+
+type internalError struct {
+	origin error
+	msg    string
+}
+
+func newInternalError(origin error, msg string) *internalError {
+	return &internalError{origin: origin, msg: msg}
+}
+
+func (i internalError) Error() string {
+	return fmt.Sprintf("%s: %v", i.msg, i.origin)
+}

--- a/handlers/map.go
+++ b/handlers/map.go
@@ -23,7 +23,7 @@ func NewMap(handlersMap map[string]amqpRecipient.JobHandler, keyFn func(delivery
 func (m *MapHandler) Handle(d *amqp.Delivery) (uint8, error) {
 	key, err := m.keyFn(d)
 	if nil != err {
-		return m.onErrorResult, fmt.Errorf("fail to compute handler key: %v", err)
+		return m.onErrorResult, newInternalError(err, "fail to compute handler key")
 	}
 
 	handler, ok := m.handlersMap[key]
@@ -31,5 +31,5 @@ func (m *MapHandler) Handle(d *amqp.Delivery) (uint8, error) {
 		return handler.Handle(d)
 	}
 
-	return m.onErrorResult, fmt.Errorf("handler not found for key '%s'", key)
+	return m.onErrorResult, newInternalError(fmt.Errorf("key '%s'", key), "handler not found")
 }

--- a/handlers/map_test.go
+++ b/handlers/map_test.go
@@ -74,7 +74,7 @@ func TestMapHandler_HandleKeyFuncFails(t *testing.T) {
 		return
 	}
 
-	if "handler not found for key 'bar'" != err.Error() {
+	if "handler not found: key 'bar'" != err.Error() {
 		t.Error("Unexpected error message")
 	}
 

--- a/handlers/publish_failed.go
+++ b/handlers/publish_failed.go
@@ -42,7 +42,7 @@ func (f PublishFailedHandler) Handle(d *amqp.Delivery) (uint8, error) {
 			newHeaders["x-"+k] = v
 		}
 
-		err := f.Sender.Send(amqp.Publishing{
+		pubErr := f.Sender.Send(amqp.Publishing{
 			Headers:         newHeaders,
 			ContentType:     d.ContentType,
 			ContentEncoding: d.ContentEncoding,
@@ -58,9 +58,11 @@ func (f PublishFailedHandler) Handle(d *amqp.Delivery) (uint8, error) {
 			AppId:           d.AppId,
 			Body:            d.Body,
 		})
-		if nil != err {
-			return 1, err
+		if nil != pubErr {
+			return amqpRecipient.HandlerRequeue, newInternalError(pubErr, "sending failed message fails")
 		}
+
+		return amqpRecipient.HandlerAck, err
 	}
 
 	return res, nil

--- a/handlers/publish_failed_test.go
+++ b/handlers/publish_failed_test.go
@@ -33,12 +33,12 @@ func TestPublishFailedHandler_HandleWithError(t *testing.T) {
 		t.Error("Sender was not called")
 	}
 
-	if nil != err {
-		t.Errorf("Handler error is %s; nil expected", err.Error())
+	if nil == err {
+		t.Error("Handler error is nil; foo expected")
 	}
 
-	if res != 2 {
-		t.Errorf("Handler result is %d; 2 expected", res)
+	if res != 0 {
+		t.Errorf("Handler result is %d; 0 expected", res)
 	}
 }
 

--- a/handlers/retry.go
+++ b/handlers/retry.go
@@ -18,10 +18,10 @@ func (r *RetryHandler) Handle(d *amqp.Delivery) (res uint8, err error) {
 	res, err = r.origin.Handle(d)
 	if nil != err {
 		if xDeath(d.Headers) >= r.maxRetries {
-			return 0, err
+			return recipient.HandlerAck, err
 		}
 
-		return 2, nil
+		return recipient.HandlerReject, nil
 	}
 
 	return


### PR DESCRIPTION
change PublishFailed handler behavior when origin fails, use result const instead numbers